### PR TITLE
[Phases] Change feet stepType for double support in ZMPDiscretization

### DIFF
--- a/src/ZMPRefTrajectoryGeneration/ZMPDiscretization.cpp
+++ b/src/ZMPRefTrajectoryGeneration/ZMPDiscretization.cpp
@@ -1111,7 +1111,7 @@ void ZMPDiscretization::EndPhaseOfTheWalking(
   LeftFootAbsolutePosition.time = RightFootAbsolutePosition.time =
       m_CurrentTime;
 
-  LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 0;
+  LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 10;
 
   FinalLeftFootAbsolutePositions.push_back(LeftFootAbsolutePosition);
   FinalRightFootAbsolutePositions.push_back(RightFootAbsolutePosition);
@@ -1147,7 +1147,7 @@ void ZMPDiscretization::EndPhaseOfTheWalking(
     LeftFootAbsolutePosition.time = RightFootAbsolutePosition.time =
         m_CurrentTime;
 
-    LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 0;
+    LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 10;
 
     FinalLeftFootAbsolutePositions.push_back(LeftFootAbsolutePosition);
     FinalRightFootAbsolutePositions.push_back(RightFootAbsolutePosition);
@@ -1194,7 +1194,7 @@ void ZMPDiscretization::EndPhaseOfTheWalking(
     LeftFootAbsolutePosition.time = RightFootAbsolutePosition.time =
         m_CurrentTime;
 
-    LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 0;
+    LeftFootAbsolutePosition.stepType = RightFootAbsolutePosition.stepType = 10;
 
     FinalLeftFootAbsolutePositions.push_back(LeftFootAbsolutePosition);
     FinalRightFootAbsolutePositions.push_back(RightFootAbsolutePosition);


### PR DESCRIPTION
Now = 10 to be coherent with the stepTypes used in the whole project.

This PR is linked with the one in [sot-pattern-generator](https://github.com/stack-of-tasks/sot-pattern-generator/pull/27), to create a coherent Phase Signal to use the PG online. 
@olivier-stasse can you check it does not break the phase file created offline ?