### PR TITLE
const correctness for C++17

### DIFF
--- a/src/Mathematics/ConvexHull.cpp
+++ b/src/Mathematics/ConvexHull.cpp
@@ -35,7 +35,7 @@ using namespace std;
 namespace PatternGeneratorJRL {
 CH_Point HRP2CIO_GlobalP0;
 struct ltCH_Point {
-  bool operator()(const CH_Point &s1, const CH_Point &s2) {
+  bool operator()(const CH_Point &s1, const CH_Point &s2) const {
     double x1, x2, y1, y2;
     x1 = s1.col - HRP2CIO_GlobalP0.col;
     x2 = s2.col - HRP2CIO_GlobalP0.col;


### PR DESCRIPTION
fix:
```
/usr/bin/g++ -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DBOOST_MPL_LIMIT_VECTOR_SIZE=30 -DHAVE_SYS_TIME_H -DHPP_FCL_HAS_OCTOMAP -DHPP_FCL_HAVE_OCTOMAP -DOCTOMAP_MAJOR_VERSION=1 -DOCTOMAP_MINOR_VERSION=9 -DOCTOMAP_PATCH_VERSION=6 -DPINOCCHIO_WITH_HPP_FCL -DPINOCCHIO_WITH_URDFDOM -DUSE_QUADPROG=1 -Djrl_walkgen_EXPORTS -I/local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7 -I/local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/include -I/local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/src -I/local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/src/FootTrajectoryGeneration -isystem /usr/include/eigen3 -isystem /opt/openrobots/include -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion   -pipe  -O3 -DNDEBUG -O3 -DNDEBUG  -fPIC -msse -msse2 -msse3 -march=core2 -mfpmath=sse -fivopts -ftree-loop-im -fipa-pta  -o CMakeFiles/jrl-walkgen.dir/src/Mathematics/ConvexHull.cpp.o -c /local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/src/Mathematics/ConvexHull.cpp
In file included from /usr/include/c++/11/set:60,
from /local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/src/Mathematics/ConvexHull.cpp:28:
/usr/include/c++/11/bits/stl_tree.h: In instantiation of 'static const _Key& std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_S_key(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type) [with _Key = PatternGeneratorJRL::CH_Point; _Val = PatternGeneratorJRL::CH_Point; _KeyOfValue = std::_Identity; _Compare = PatternGeneratorJRL::ltCH_Point; _Alloc = std::allocator; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type = const std::_Rb_tree_node*]':
/usr/include/c++/11/bits/stl_tree.h:2069:47:   required from 'std::pair std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_get_insert_unique_pos(const key_type&) [with _Key = PatternGeneratorJRL::CH_Point; _Val = PatternGeneratorJRL::CH_Point; _KeyOfValue = std::_Identity; _Compare = PatternGeneratorJRL::ltCH_Point; _Alloc = std::allocator; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::key_type = PatternGeneratorJRL::CH_Point]'
/usr/include/c++/11/bits/stl_tree.h:2122:4:   required from 'std::pair, bool> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_insert_unique(_Arg&&) [with _Arg = const PatternGeneratorJRL::CH_Point&; _Key = PatternGeneratorJRL::CH_Point; _Val = PatternGeneratorJRL::CH_Point; _KeyOfValue = std::_Identity; _Compare = PatternGeneratorJRL::ltCH_Point; _Alloc = std::allocator]'
/usr/include/c++/11/bits/stl_set.h:512:25:   required from 'std::pair, _Compare, typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key>::other>::const_iterator, bool> std::set<_Key, _Compare, _Alloc>::insert(const value_type&) [with _Key = PatternGeneratorJRL::CH_Point; _Compare = PatternGeneratorJRL::ltCH_Point; _Alloc = std::allocator; typename std::_Rb_tree<_Key, _Key, std::_Identity<_Tp>, _Compare, typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key>::other>::const_iterator = std::_Rb_tree, PatternGeneratorJRL::ltCH_Point, std::allocator >::const_iterator; typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key>::other = std::allocator; typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key> = __gnu_cxx::__alloc_traits, PatternGeneratorJRL::CH_Point>::rebind; typename _Alloc::value_type = PatternGeneratorJRL::CH_Point; std::set<_Key, _Compare, _Alloc>::value_type = PatternGeneratorJRL::CH_Point]'
/local/robotpkg/var/tmp/robotpkg/wip/jrl-walkgen-v3/work/jrl-walkgen-4.2.7/src/Mathematics/ConvexHull.cpp:121:37:   required from here
/usr/include/c++/11/bits/stl_tree.h:770:15: error: static assertion failed: comparison object must be invocable as const
770 |               is_invocable_v,
|               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/11/bits/stl_tree.h:770:15: note: 'std::is_invocable_v' evaluates to false
``` 